### PR TITLE
ci: add CI to make sure codegen is always consistent with spec change

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -48,9 +48,10 @@ jobs:
           java-version: 11
           cache: "maven"
       - name: Install openapi-generator
-        run: pip install openapi-generator-cli
+        run: pip install --user ci openapi-generator-cli
       - name: list
-        run: ls ~/.local/bin
+        run: |
+          ls ~/.local/bin/ci
       - name: Generate Java
         working-directory: java
         run: make gen

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Add Python requirement to enable caching
-        run: touch ./requirements.txt
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Set up npm
-        uses: actions/setup-node@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          node-version: 20
-          cache: 'npm'
+          python-version: '3.13'
+          cache: 'pip'
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -46,7 +46,7 @@ jobs:
           java-version: 11
           cache: "maven"
       - name: Install openapi-generator
-        run: npm install @openapitools/openapi-generator-cli -g
+        run: pip install openapi-generator-cli
       - name: Generate Java
         working-directory: java
         run: make gen

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -57,4 +57,12 @@ jobs:
         working-directory: rust
         run: make gen
       - name: Check no difference in codegen
-        run: git diff
+        run: |
+          output=$(git diff)
+          if [ -z "$output" ]; then
+            echo "There is no difference in codegen"
+          else
+            echo "Detected difference in codegen"
+            echo "$output"
+            exit 1
+          fi

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -48,10 +48,10 @@ jobs:
           java-version: 11
           cache: "maven"
       - name: Install openapi-generator
-        run: pip install --user ci openapi-generator-cli
+        run: pip install --user openapi-generator-cli
       - name: list
         run: |
-          ls ~/.local/bin/ci
+          ls ~/.local/bin
       - name: Generate Java
         working-directory: java
         run: make gen

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -49,6 +49,8 @@ jobs:
           cache: "maven"
       - name: Install openapi-generator
         run: pip install openapi-generator-cli
+      - name: list
+        run: ls ~/.local/bin
       - name: Generate Java
         working-directory: java
         run: make gen

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Add Python requirement to enable caching
+        run: touch ./requirements.txt
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Spec
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-spec-codegen:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: "maven"
+      - name: Install openapi-generator
+        run: npm install @openapitools/openapi-generator-cli -g
+      - name: Generate Java
+        working-directory: java
+        run: make gen
+      - name: Generate Rust
+        working-directory: rust
+        run: make gen
+      - name: Check no difference in codegen
+        run: git diff

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,12 @@ test_data/venv
 
 **/*.profraw
 *.lance
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ and invoke operations in Lance Catalog to read, write and manage Lance tables in
 
 ## Development Guide
 
-## Install OpenAPI Generator
+### Install OpenAPI Generator
 
-We use OpenAPI Generator to generate various clients and servers for the catalog specification.
-We recommend installing the tool through pip for consistent experience across platforms.
+We use [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) 
+to generate various clients and servers for the catalog specification.
+We recommend installing the tool through [pip](https://pypi.org/project/openapi-generator-cli/) 
+for consistent experience across platforms.
 First time setup of virtual environment and installation:
 
 ```bash
@@ -30,7 +32,7 @@ source .env/bin/activate
 pip install -r requirements.txt
 ```
 
-## Develop Rust
+### Develop Rust
 
 ```bash
 cd rust
@@ -41,11 +43,14 @@ make clean
 # clean, and then generate all clients and servers
 make gen 
 
+# clean and generate the rust reqwest client
+make gen-rust-reqwest-client
+
 # clean, generate and build the modules 
 make build
 ```
 
-## Develop Java
+### Develop Java
 
 ```bash
 cd java
@@ -55,6 +60,12 @@ make clean
 
 # clean, and then generate all clients and servers
 make gen 
+
+# clean and generate the Java Apache client
+make gen-java-apache-client
+
+# clean and generate the Java Spring Boot server
+make gen-java-springboot-server
 
 # clean, generate and build the modules 
 make build

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make gen
 # clean and generate the rust reqwest client
 make gen-rust-reqwest-client
 
-# clean, generate and build the modules 
+# clean, generate and build all clients and servers
 make build
 ```
 
@@ -67,6 +67,6 @@ make gen-java-apache-client
 # clean and generate the Java Spring Boot server
 make gen-java-springboot-server
 
-# clean, generate and build the modules 
+# clean, generate and build all clients and servers
 make build
 ```

--- a/README.md
+++ b/README.md
@@ -15,3 +15,47 @@ and invoke operations in Lance Catalog to read, write and manage Lance tables in
 | [rust/lance-catalog-reqwest-client](./rust/lance-catalog-reqwest-client)       | Generated Rust reqwest client for Lance Catalog     |
 | [java/lance-catalog-apache-client](./java/lance-catalog-apache-client)         | Generated Java Apache HTTP client for Lance Catalog |
 | [java/lance-catalog-springboot-server](./java/lance-catalog-springboot-server) | Generated Java SpringBoot server for Lance          |
+
+## Development Guide
+
+## Install OpenAPI Generator
+
+We use OpenAPI Generator to generate various clients and servers for the catalog specification.
+We recommend installing the tool through pip for consistent experience across platforms.
+First time setup of virtual environment and installation:
+
+```bash
+python3 -m venv .env
+source .env/bin/activate
+pip install -r requirements.txt
+```
+
+## Develop Rust
+
+```bash
+cd rust
+
+# clean all existing generated modules
+make clean
+
+# clean, and then generate all clients and servers
+make gen 
+
+# clean, generate and build the modules 
+make build
+```
+
+## Develop Java
+
+```bash
+cd java
+
+# clean all existing generated modules
+make clean
+
+# clean, and then generate all clients and servers
+make gen 
+
+# clean, generate and build the modules 
+make build
+```

--- a/java/Makefile
+++ b/java/Makefile
@@ -11,7 +11,7 @@ gen-java-apache-client: clean-java-apache-client
 	  -o lance-catalog-apache-client \
 	  --ignore-file-override=.apache-client-ignore \
 	  --additional-properties=groupId=com.lancedb,artifactId=lance-catalog-apache-client,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-catalog-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=apache-httpclient,apiPackage=com.lancedb.lance.catalog.client.apache.api,modelPackage=com.lancedb.lance.catalog.client.apache.model,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt
-	sed -i '' -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
+	#sed -i '' -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
 	./mvnw spotless:apply
 
 build-java-apache-client: gen-java-apache-client

--- a/java/Makefile
+++ b/java/Makefile
@@ -11,7 +11,7 @@ gen-java-apache-client: clean-java-apache-client
 	  -o lance-catalog-apache-client \
 	  --ignore-file-override=.apache-client-ignore \
 	  --additional-properties=groupId=com.lancedb,artifactId=lance-catalog-apache-client,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-catalog-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=apache-httpclient,apiPackage=com.lancedb.lance.catalog.client.apache.api,modelPackage=com.lancedb.lance.catalog.client.apache.model,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt
-	#sed -i '' -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
+	sed -i '' -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
 	./mvnw spotless:apply
 
 build-java-apache-client: gen-java-apache-client

--- a/java/Makefile
+++ b/java/Makefile
@@ -11,7 +11,8 @@ gen-java-apache-client: clean-java-apache-client
 	  -o lance-catalog-apache-client \
 	  --ignore-file-override=.apache-client-ignore \
 	  --additional-properties=groupId=com.lancedb,artifactId=lance-catalog-apache-client,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-catalog-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=apache-httpclient,apiPackage=com.lancedb.lance.catalog.client.apache.api,modelPackage=com.lancedb.lance.catalog.client.apache.model,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt
-	sed -i '' -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
+	sed -i -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
+	rm -f lance-catalog-apache-client/pom.xml-e
 	./mvnw spotless:apply
 
 build-java-apache-client: gen-java-apache-client

--- a/java/Makefile
+++ b/java/Makefile
@@ -5,7 +5,7 @@ clean-java-apache-client:
 	rm -rf lance-catalog-apache-client
 
 gen-java-apache-client: clean-java-apache-client
-	openapi-generator generate \
+	openapi-generator-cli generate \
 	  -i ../spec/catalog.yaml \
 	  -g java \
 	  -o lance-catalog-apache-client \
@@ -21,7 +21,7 @@ clean-java-springboot-server:
 	rm -rf lance-catalog-springboot-server
 
 gen-java-springboot-server: clean-java-springboot-server
-	openapi-generator generate \
+	openapi-generator-cli generate \
 	  -i ../spec/catalog.yaml \
 	  -g spring \
       -o lance-catalog-springboot-server \

--- a/java/Makefile
+++ b/java/Makefile
@@ -12,6 +12,9 @@ gen-java-apache-client: clean-java-apache-client
 	  --ignore-file-override=.apache-client-ignore \
 	  --additional-properties=groupId=com.lancedb,artifactId=lance-catalog-apache-client,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-catalog-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=apache-httpclient,apiPackage=com.lancedb.lance.catalog.client.apache.api,modelPackage=com.lancedb.lance.catalog.client.apache.model,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt
 	sed -i '' -e 's#<junit-version>5.10.2</junit-version>#<junit-version>5.8.2</junit-version>#g' lance-catalog-apache-client/pom.xml
+	./mvnw spotless:apply
+
+build-java-apache-client: gen-java-apache-client
 	./mvnw install -pl lance-catalog-apache-client -am
 
 clean-java-springboot-server:
@@ -23,8 +26,13 @@ gen-java-springboot-server: clean-java-springboot-server
 	  -g spring \
       -o lance-catalog-springboot-server \
       --additional-properties=groupId=com.lancedb,artifactId=lance-catalog-springboot-server,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-catalog-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=spring-boot,interfaceOnly=true,useOptional=true,openApiNullable=false,java8=true,apiPackage=com.lancedb.lance.catalog.server.springboot.api,modelPackage=com.lancedb.lance.catalog.server.springboot.model,useTags=true,skipDefaultInterface=false,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt
+	./mvnw spotless:apply
+
+build-java-springboot-server: gen-java-springboot-server
 	./mvnw install -pl lance-catalog-springboot-server -am
 
 clean: clean-java-apache-client clean-java-springboot-server
 
 gen: gen-java-apache-client gen-java-springboot-server
+
+build: build-java-apache-client build-java-springboot-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openapi-generator-cli>=7.12.0

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -5,7 +5,7 @@ clean-rust-reqwest-client:
 	rm -rf lance-catalog-reqwest-client
 
 gen-rust-reqwest-client: clean-rust-reqwest-client
-	openapi-generator generate \
+	openapi-generator-cli generate \
 	  -i ../spec/catalog.yaml \
 	  -g rust \
 	  -o lance-catalog-reqwest-client \

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -11,6 +11,11 @@ gen-rust-reqwest-client: clean-rust-reqwest-client
 	  -o lance-catalog-reqwest-client \
 	  --additional-properties=packageName=lance-catalog-reqwest-client,packageVersion=$(VERSION),asyncApi=true,library=reqwest
 
+build-rust-reqwest-client: gen-rust-reqwest-client
+	cargo test
+
 clean: clean-rust-reqwest-client
 
 gen: gen-rust-reqwest-client
+
+build: build-rust-reqwest-client


### PR DESCRIPTION
Introduce a CI workflow that compares the current commit vs the one that runs all the codegen to check if the two have difference.

Move to use `openapi-generator-cli` that is supported in all platforms.

Add related instructions in README.

Fixes #24 